### PR TITLE
allow paragraphs to start with '('

### DIFF
--- a/ahrf.awk
+++ b/ahrf.awk
@@ -23,7 +23,7 @@ BEGIN { FS = "\n"; RS = "" }
 }
 
 # Paragraph
-/^[A-Za-z0-9_]+/ {
+/^[A-Za-z0-9_(]+/ {
 	printf("<p>%s</p>\n\n", $0)
 	next
 }


### PR DESCRIPTION
I just had a case with a paragraph starting with a '('.
I see no reason to not allow it, do you?
